### PR TITLE
EDGE CASE: allow download for other repositories

### DIFF
--- a/content/posts/2025/4-how-to-workaround-ollama-pull-issues/index.md
+++ b/content/posts/2025/4-how-to-workaround-ollama-pull-issues/index.md
@@ -44,27 +44,35 @@ _=$(command -v curl) || die "Need curl"
 
 [ -z "$1" ] && die "usage: $0 modelname"
 
-name=${1%%:*}
+input="${1%%:*}"
 [[ "$1" = *:* ]] && tag="${1##*:}" || tag=latest
 
 OLLAMA_MODELS=${OLLAMA_MODELS-/usr/share/ollama/.ollama/models}
 
-cd $OLLAMA_MODELS || die "Couldn't cd to OLLAMA_MODELS ($OLLAMA_MODELS)"
+cd "$OLLAMA_MODELS" || die "Couldn't cd to OLLAMA_MODELS ($OLLAMA_MODELS)"
 [ ! -d blobs -o ! -d manifests ] && die "Missing blobs or manifests directory"
-manifest_dir="manifests/registry.ollama.ai/library/$name"
-[ -e "$manifest_dir/$tag" ] && die "$name:$tag already exists"
+
+# Determine registry path
+if [[ "$input" == */* ]]; then
+  registry_path="${input}"
+else
+  registry_path="library/$input"
+fi
+
+manifest_dir="manifests/registry.ollama.ai/$registry_path"
+[ -e "$manifest_dir/$tag" ] && die "$input:$tag already exists"
 [ ! -d "$manifest_dir" ] && { $DRYRUN mkdir -p "$manifest_dir" || die "Couldn't mkdir manifest dir ($manifest_dir)" ; }
 
-manifest=$(curl -sL https://registry.ollama.ai/v2/library/$name/manifests/$tag) || die "Couldn't fetch manifest"
+manifest=$(curl -sL "https://registry.ollama.ai/v2/$registry_path/manifests/$tag") || die "Couldn't fetch manifest"
 errors=$(jq -cn "$manifest |.errors")
 [ "$errors" = "null" ] || die "$errors"
 
 config=$(jq -rn "$manifest | .config.digest") || die "No config digest"
 
-$DRYRUN curl -#L -C - -o blobs/${config/:/-} https://registry.ollama.ai/v2/library/$name/blobs/$config || die "Couldn't fetch config blob"
+$DRYRUN curl -#L -C - -o "blobs/${config/:/-}" "https://registry.ollama.ai/v2/$registry_path/blobs/$config" || die "Couldn't fetch config blob"
 
 for layer in $(jq -rn "$manifest | .layers[].digest") ; do
-  $DRYRUN curl -#L -C - -o blobs/${layer/:/-} https://registry.ollama.ai/v2/library/$name/blobs/$layer || die "Couldn't fetch layer"
+  $DRYRUN curl -#L -C - -o "blobs/${layer/:/-}" "https://registry.ollama.ai/v2/$registry_path/blobs/$layer" || die "Couldn't fetch layer"
 done
 
 [ -n "$DRYRUN" ] && echo "echo '$manifest' > '$manifest_dir/$tag'" || { echo "$manifest" > "$manifest_dir/$tag" || die "Couldn't write manifest" ; }


### PR DESCRIPTION
Some models are not in "library" path but under 

For example : https://ollama.com/zongwei/gemma3-translator instead of https://ollama.com/library/gemma3-translator, which are pulled like that with standard ollama command :
`ollama pull zongwei/gemma3-translator:4b`

This change should fix it.
PS : thanks for your blog posts, you saved me a lot of time !